### PR TITLE
Require host:port information for ElasticSearch

### DIFF
--- a/incertitude.py
+++ b/incertitude.py
@@ -3,7 +3,7 @@
 geocoder for possibly ambiguous input queries.
 
 Usage:
-  incertitude.py <mapping_file.json> <geonames_file_path> <settings_file.json>
+  incertitude.py <mapping_file.json> <geonames_file_path> <settings_file.json> <host:port>
   incertitude.py (-h | --help)
   incertitude.py --version
 
@@ -23,6 +23,7 @@ if __name__ == '__main__':
     db_path = arguments["<geonames_file_path>"]
     mapping_file = arguments["<mapping_file.json>"]
     settings_file = arguments["<settings_file.json>"]
+    host, port = arguments["<host:port>"].split(":")
 
     with file(mapping_file) as f:
         mapping = json.load(f)
@@ -30,8 +31,7 @@ if __name__ == '__main__':
     with file(settings_file) as f:
         settings = json.load(f)
 
-    # by default we connect to localhost:9200
-    es = Elasticsearch()
+    es = Elasticsearch([{"host": host, "port": port}])
 
     body = {
         "settings": settings,


### PR DESCRIPTION
Resolves #2
